### PR TITLE
feat: Implement minimizable DebugOverlay

### DIFF
--- a/src/components/DebugOverlay.jsx
+++ b/src/components/DebugOverlay.jsx
@@ -1,12 +1,34 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import { useDebug } from '../contexts/DebugContext';
 
 export default function DebugOverlay() {
   const { logs } = useDebug();
+  const [isMinimized, setIsMinimized] = useState(true);
 
-  const overlayStyle = {
+  const toggleMinimize = () => {
+    setIsMinimized(!isMinimized);
+  };
+
+  const minimizedStyle = {
+    position: 'fixed',
+    bottom: '10px',
+    right: '10px',
+    width: '40px',
+    height: '40px',
+    backgroundColor: 'rgba(0, 0, 0, 0.7)',
+    color: 'white',
+    borderRadius: '50%',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    cursor: 'pointer',
+    zIndex: 9999,
+    fontSize: '20px',
+  };
+
+  const maximizedStyle = {
     position: 'fixed',
     bottom: '10px',
     left: '10px',
@@ -21,14 +43,23 @@ export default function DebugOverlay() {
     fontFamily: 'monospace',
     zIndex: 9999, // Ensure it's on top
     opacity: 0.8,
+    cursor: 'pointer', // Added cursor pointer
   };
 
-  return (
-    <div style={overlayStyle}>
-      <div>**Debug Log Overlay**</div>
-      {logs.map((log, index) => (
-        <div key={index}>{log}</div>
-      ))}
-    </div>
-  );
+  if (isMinimized) {
+    return (
+      <div style={minimizedStyle} onClick={toggleMinimize}>
+        {'🐞'}
+      </div>
+    );
+  } else {
+    return (
+      <div style={maximizedStyle} onClick={toggleMinimize}>
+        <div>**Debug Log Overlay**</div>
+        {logs.map((log, index) => (
+          <div key={index}>{log}</div>
+        ))}
+      </div>
+    );
+  }
 } 


### PR DESCRIPTION
The DebugOverlay component in src/components/ can now be minimized and maximized.

Key changes:
- Added `isMinimized` state to `DebugOverlay.jsx`, defaulting to `true`.
- Implemented `toggleMinimize` function to switch between states.
- Conditionally renders a bug icon ('🐞') when minimized and the full log view when maximized.
- Minimized view is a small circular button fixed to the bottom-right of the screen.
- Maximized view retains its original position and appearance at the bottom-left.
- Click handlers are added to both views to toggle the state.
- Styles have been updated for both states, ensuring clarity and usability. The minimized icon is white for better contrast.
- Conceptual unit tests have been outlined to verify the new functionality.